### PR TITLE
added pv template and values file

### DIFF
--- a/templates/persistant-volume.yaml
+++ b/templates/persistant-volume.yaml
@@ -1,0 +1,40 @@
+{{- $replicas := int .Values.server.replicas }}
+{{- $pvBaseName := .Values.persistentVolume.name }}
+{{- $pvReclaimPolicy := .Values.persistentVolume.reclaimPolicy }}
+{{- $pvStorageClass := .Values.persistentVolume.storageClass }}
+{{- $pvStorage := .Values.server.storage }}
+{{- $pvAccessMode := .Values.persistentVolume.accessMode }}
+{{- $pvLocalPath := .Values.persistentVolume.local.path }}
+{{- $pvNodeAffinityKey := .Values.persistentVolume.nodeAffinity.key }}
+{{- $pvNodeAffinityOperator := .Values.persistentVolume.nodeAffinity.operator }}
+{{- $pvNodeAffinityNode := .Values.persistentVolume.nodeAffinity.node }}
+
+{{- range $i, $_ := until $replicas }}
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ printf "%s-%d" $pvBaseName $i }}
+spec:
+  persistentVolumeReclaimPolicy: {{ $pvReclaimPolicy }}
+  storageClassName: {{ $pvStorageClass }}
+  capacity:
+    storage: {{ $pvStorage }}
+  accessModes:
+    - {{ $pvAccessMode }}
+  local:
+    path: "{{ $pvLocalPath }}"
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: {{ $pvNodeAffinityKey }}
+          operator: {{ $pvNodeAffinityOperator }}
+          values:
+          - {{ $pvNodeAffinityNode }}
+
+{{- if ne $i (sub $replicas 1) }}
+---
+{{- end }}
+
+{{- end }}

--- a/values.local.yaml
+++ b/values.local.yaml
@@ -1,0 +1,64 @@
+global:
+  enabled: true
+  logLevel: "info"
+  name: consul-mesh
+  domain: consul
+  peering:
+    enabled: false
+  image: hashicorp/consul:1.17.2
+  imagePullSecrets: []
+  resources:
+    requests:
+      memory: "500Mi"
+      cpu: "0.5"
+    limits:
+      memory: "1Gi"
+      cpu: "1"
+server:
+  enabled: "true"
+  logLevel: ""
+  image: null
+  replicas: 3
+  bootstrapExpect: null
+  storage: 500Mi
+  storageClass: local-storage
+  affinity: |
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node
+            operator: In
+            values:
+            - master
+  tolerations: |
+    - key: "CriticalAddonsOnly"
+      operator: "Equal"
+      value: "true"
+      effect: "NoExecute"
+
+ui:
+  enabled: true
+  service:
+    enabled: true
+    type: NodePort
+    nodePort:
+      http: 30099
+      https: null
+
+connectInject:
+  enabled: false
+  image: null
+  default: false
+
+persistentVolume:
+  name: consul-pv
+  reclaimPolicy: Retain
+  storageClass: local-storage
+  accessMode: ReadWriteOnce
+  local:
+    path: "/data"
+  nodeAffinity:
+    key: node
+    operator: In
+    node: master


### PR DESCRIPTION
Changes proposed in this PR:
- PV provision for local-storage

How I've tested this PR:

helm template consul consul/ --values values.local.yaml > test.yaml
kubectl apply -f test.yaml


How I expect reviewers to test this PR:
helm template consul consul/ --values values.local.yaml > test.yaml 
kubectl apply -f test.yaml (look for PV, PVC and pod status)

Checklist:
- [ ] PV Enabled
- [ ] CHANGELOG Added template file for PV creation and template values.local.yaml

